### PR TITLE
Fix for Rails 7.1+ & Kaminari pagination

### DIFF
--- a/config-parser.gemspec
+++ b/config-parser.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = ['lib']
-  gem.version = '0.4.0'
+  gem.version = '0.4.1'
   gem.license = 'MIT'
+  gem.add_dependency 'deep_merge', '~> 1.2', '>= 1.2.1'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-its'
-  gem.add_development_dependency 'deep_merge'
 end

--- a/lib/common/options.rb
+++ b/lib/common/options.rb
@@ -22,7 +22,7 @@
 
 require 'yaml'
 require 'erb'
-require 'deep_merge'
+require 'deep_merge/core'
 
 require "#{File.dirname(__FILE__)}/utils"
 


### PR DESCRIPTION
This specific combination surfaced an issue caused by `deep_merge` taking precedence over `ActiveSupport::DeepMergeable.deep_merge`. Requiring "deep_merge/core" and upgrading the dependency to the latest version fixes the issue.

Details: 
- https://github.com/kaminari/kaminari/issues/1119
- https://github.com/rails/rails/commit/43b980368a7628fac95cc4f673e0dfbcee77c10b